### PR TITLE
conda no need LEGACY; add TERMINFO

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -9,9 +9,12 @@ alias ls='ls --color=auto'
 alias grep='grep --color=auto'
 PS1='[\u@\h \W]\$ '
 
+#Set up my custom command
+export USER_CUSTOM=$HOME/UserCustom
+[ -f $USER_CUSTOM/mybash.sh ] && source $USER_CUSTOM/mybash.sh
+
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
 __conda_setup="$('/opt/miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
@@ -24,10 +27,6 @@ else
 fi
 unset __conda_setup
 # <<< conda initialize <<<
-
-#Set up my custom command
-export USER_CUSTOM=$HOME/UserCustom
-[ -f $USER_CUSTOM/mybash.sh ] && source $USER_CUSTOM/mybash.sh
 
 #fzf
 source "/usr/share/fzf/key-bindings.bash"

--- a/env.sh
+++ b/env.sh
@@ -2,6 +2,7 @@ export LANG=en_US.UTF-8
 export VISUAL=nvim
 export EDITOR=nvim
 export TERMINAL=konsole
+export TERMINFO=/usr/share/terminfo
 export PATH=$HOME/.local/bin:$USER_CUSTOM/bin:$PATH
 export PYTHONPYCACHEPREFIX=/tmp
 export XZ_DEFAULTS='-T0'

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -17,9 +17,8 @@ else
 fi
 
 # >>> conda initialize >>>
-export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/opt/miniconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
+__conda_setup="$('/opt/miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else


### PR DESCRIPTION
Conda 已經不需要 export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1。
env.sh 添加 export TERMINFO=/usr/share/terminfo ，否則conda會導致 <clear> 衝突。
改變一些無關緊要的順序（美觀）。